### PR TITLE
changed line 66 so we're casting the integer to decimal

### DIFF
--- a/HW_wk3.sql
+++ b/HW_wk3.sql
@@ -63,7 +63,7 @@ VALUES
 -- What is the carbon intensity (tons of CO2 produced per thousands of megawatt hours generated) for coal, gas, and petroleum in 2013?
 
 SELECT 
-NetGen_2013.Source, NetGen, Emissions_2013, Emissions_2013 / NetGen AS Carbon_Intensity
+NetGen_2013.Source, NetGen, Emissions_2013, Emissions_2013 / CAST(NetGen AS DECIMAL) AS Carbon_Intensity
 FROM NetGen_2013
 JOIN GenNames
 ON NetGen_2013.Source = GenNames.NetGenName


### PR DESCRIPTION
A division with integers returns the integer part. (2/5 = 0). Casting at least one of the operands to a decimal should make it give you a full blown decimal number (2/CAST(5 AS DECIMAL) = 0.4.

I also posted a comment on blackboard
